### PR TITLE
Pari korjausta sanastoon

### DIFF
--- a/sdc_en-fi.md
+++ b/sdc_en-fi.md
@@ -41,7 +41,7 @@ kaikki kattavaan yleistermiin *tieto*.
 | falsified data                               | vääristetty aineisto
 | feasibility interval                         | peittämisväli
 | frequency table                              | lukumäärätaulukko
-| generalization                               | karkeistaminen
+| generalization                               | yleistäminen
 | identifiability                              | tunnistettavuus
 | identifier                                   | (suora) tunniste
 | identity disclosure                          | identiteetin paljastuminen
@@ -108,5 +108,5 @@ kaikki kattavaan yleistermiin *tieto*.
 | k-anonymity                                  | k-anonymiteetti
 | l-diversity                                  | l-diversiteetti
 | t-closeness                                  | t-läheisyys
-| (epsilon) differential privacy               | differentiaalinen yksityisyys
+| (epsilon) differential privacy               | differentiaalinen tietosuoja
 


### PR DESCRIPTION
Alla pari korjausehdotusta. Generalization särähti korvaan, kun minusta karkeistaminen on coarsening. Asiaa pohdittuani pidän differentiaalista tietosuojaa parempana käännöksenä DP:lle, se yksityisyys on vähän kömpelö. Mm. Apple käyttää myös suomennoksissaan tuota tietosuojaa.